### PR TITLE
Initialize Cypress framework

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+max_line_length = off
+trim_trailing_whitespace = false

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,16 @@
+module.exports = {
+  env: {
+    es2021: true,
+    node: true,
+    mocha: true,
+  },
+  extends: [
+    'airbnb-base',
+    'plugin:prettier/recommended',
+  ],
+  parserOptions: {
+    ecmaVersion: 12,
+    sourceType: 'module',
+  },
+  rules: {},
+};

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+node_modules/
+.env
+coverage/
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# OS files
+.DS_Store
+
+# Cypress
+cypress/videos/
+cypress/screenshots/
+

--- a/.husky/_/husky.sh
+++ b/.husky/_/husky.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+if [ -z "$husky_skip_init" ]; then
+  debug() {
+    [ "$HUSKY_DEBUG" = "1" ] && echo "husky (debug) - $*"
+  }
+  husky_skip_init=1
+  [ -f ~/.huskyrc ] && . ~/.huskyrc
+  export readonly husky_skip_init
+  sh -e "$0" "$@"
+  exit $?
+fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+npx lint-staged

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "all"
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# OSGT Cypress JS Framework
+
+This repository contains an example setup for a Cypress testing framework. The project includes configuration templates for different environments, a basic config loader utility, and sample tests.
+
+## Development Setup
+
+1. **Install Node.js** (version 18 or later).
+2. **Install dependencies** (internet access required):
+   ```bash
+   npm install
+   ```
+3. **Run Cypress tests**:
+   ```bash
+   npm test
+   ```
+
+Note: This environment does not include node modules in version control. Ensure dependencies are installed before running tests.

--- a/config/dev.json
+++ b/config/dev.json
@@ -1,0 +1,4 @@
+{
+  "env": "development",
+  "baseUrl": "http://localhost:3000"
+}

--- a/config/prod.json
+++ b/config/prod.json
@@ -1,0 +1,4 @@
+{
+  "env": "production",
+  "baseUrl": "https://example.com"
+}

--- a/config/staging.json
+++ b/config/staging.json
@@ -1,0 +1,4 @@
+{
+  "env": "staging",
+  "baseUrl": "https://staging.example.com"
+}

--- a/cypress/integration/examples/sample.spec.js
+++ b/cypress/integration/examples/sample.spec.js
@@ -1,0 +1,9 @@
+/// <reference types="cypress" />
+
+describe('Sample Test', () => {
+  it('Visits the Kitchen Sink', () => {
+    cy.visit('https://example.cypress.io');
+    cy.contains('type').click();
+    cy.url().should('include', '/commands/actions');
+  });
+});

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,0 +1,1 @@
+// Add custom commands here

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -1,0 +1,1 @@
+import './commands';

--- a/package.json
+++ b/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "osgt-crypress",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "cypress run",
+    "prepare": "husky install"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "cypress": "^13.6.5",
+    "eslint": "^8.57.0",
+    "eslint-config-airbnb-base": "^15.0.0",
+    "eslint-plugin-import": "^2.29.1",
+    "prettier": "^3.2.5",
+    "husky": "^9.0.11",
+    "lint-staged": "^15.2.0",
+    "node-fetch": "^2.6.11"
+  },
+  "lint-staged": {
+    "*.js": [
+      "eslint --fix",
+      "prettier --write"
+    ]
+  }
+}

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -1,0 +1,3 @@
+const { loadConfig } = require('./loader');
+
+module.exports = loadConfig();

--- a/src/config/loader.js
+++ b/src/config/loader.js
@@ -1,0 +1,20 @@
+const fs = require('fs');
+const path = require('path');
+
+function loadConfig(env = process.env.NODE_ENV || 'dev') {
+  const fileMap = {
+    dev: 'dev.json',
+    development: 'dev.json',
+    staging: 'staging.json',
+    prod: 'prod.json',
+    production: 'prod.json',
+  };
+
+  const fileName = fileMap[env] || 'dev.json';
+  const filePath = path.join(__dirname, '..', '..', 'config', fileName);
+  const raw = fs.readFileSync(filePath);
+  const cfg = JSON.parse(raw);
+  return cfg;
+}
+
+module.exports = { loadConfig };

--- a/src/pages/BasePage.js
+++ b/src/pages/BasePage.js
@@ -1,0 +1,11 @@
+class BasePage {
+  visit(path = '') {
+    cy.visit(path);
+  }
+
+  getTitle() {
+    return cy.title();
+  }
+}
+
+module.exports = BasePage;

--- a/src/pages/HomePage.js
+++ b/src/pages/HomePage.js
@@ -1,0 +1,9 @@
+const BasePage = require('./BasePage');
+
+class HomePage extends BasePage {
+  open() {
+    this.visit('/');
+  }
+}
+
+module.exports = new HomePage();

--- a/src/services/BaseService.js
+++ b/src/services/BaseService.js
@@ -1,0 +1,7 @@
+class BaseService {
+  constructor(baseUrl) {
+    this.baseUrl = baseUrl;
+  }
+}
+
+module.exports = BaseService;

--- a/src/services/RestService.js
+++ b/src/services/RestService.js
@@ -1,0 +1,11 @@
+const BaseService = require('./BaseService');
+const fetch = require('node-fetch');
+
+class RestService extends BaseService {
+  async get(path, options = {}) {
+    const response = await fetch(`${this.baseUrl}${path}`, { method: 'GET', ...options });
+    return response.json();
+  }
+}
+
+module.exports = RestService;


### PR DESCRIPTION
## Summary
- init node project
- add Cypress example structure
- configure ESLint (Airbnb) and Prettier
- set up Husky pre-commit hook
- add config loader utility

## Testing
- `npm test` *(fails: cypress: not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f45121540832fa87fb9c954fff4d0